### PR TITLE
ALB IdleTimeout 180sec to prevent Gateway Timeout on job submission

### DIFF
--- a/Templates/AWS-HPC-Cluster.yaml
+++ b/Templates/AWS-HPC-Cluster.yaml
@@ -843,6 +843,9 @@ Resources:
         - !If [CreateVpc, !Ref PublicSubnetB, !Ref PublicSubnetBId]
       SecurityGroups:
         - !Ref ALBSecurityGroup
+      LoadBalancerAttributes:
+        - Key: idle_timeout.timeout_seconds
+          Value: 180
 
   NetworkLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer


### PR DESCRIPTION

*Issue 10*

*Description of changes:* ALB IdleTimeout 180sec to prevent Gateway Timeout on job submission


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
