### PR TITLE
Instance tagging and mounting FSxL to Cloud9 instance

### DIFF
--- a/Templates/AWS-HPC-Cluster.yaml
+++ b/Templates/AWS-HPC-Cluster.yaml
@@ -191,7 +191,6 @@ Resources:
       Path: "/"
       Roles:
       - Ref: Cloud9Role
-
   LambdaExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -483,7 +482,7 @@ Resources:
       Description: This the password used for Admin of the custom AD directory
       SecretString: !If [CreateAD, !Ref AdminPassword, !Ref ADPassword]
 
-  Cloud9SSMDocument: 
+  Cloud9SSMDocument: # Clones 1click repo, adds environment variables, and uploads to s3 bucket. Then runs "scripts/Cloud9-Bootstrap.sh" to setup this cloud9 node
     Type: AWS::SSM::Document
     Properties: 
       DocumentType: Command
@@ -502,7 +501,7 @@ Resources:
             - echo LANG=en_US.utf-8 >> /etc/environment
             - echo LC_ALL=en_US.UTF-8 >> /etc/environment
             - cd /home/ec2-user/environment
-            - git clone "https://github.com/aws-samples/1click-hpc.git"
+            - git clone "https://github.com/aws-samples/1click-hpc"
             - !Sub echo "export AWS_DEFAULT_REGION=${AWS::Region}" >> cluster_env
             - !Sub echo "export AWS_REGION_NAME=${AWS::Region}" >> cluster_env
             - !Sub echo "export S3_BUCKET=${Cloud9OutputBucket}" >> cluster_env
@@ -564,7 +563,7 @@ Resources:
         - Cloud9InstanceProfile
         - Arn
 
-  Cloud9BootstrapInstanceLambdaFunction:
+  Cloud9BootstrapInstanceLambdaFunction:  # Attaches Instance profile to cloud9 instance
     Type: AWS::Lambda::Function
     Properties:
       Handler: index.lambda_handler
@@ -626,17 +625,17 @@ Resources:
               else:
                   cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
 
-  LogGroupCloud9BootstrapInstanceLambdaFunction:
+  LogGroupCloud9BootstrapInstanceLambdaFunction:  # Creates log group for the Cloud9BootstrapInstanceLambdaFunction
     Type: AWS::Logs::LogGroup
     DeletionPolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${Cloud9BootstrapInstanceLambdaFunction}
       RetentionInDays: 7
 
-  WaitHandle:
+  WaitHandle:  # Creates a wait handle, that the Cloud9Bootstrap script writes success to if the cluster creation and setup successful
     Type: AWS::CloudFormation::WaitConditionHandle
 
-  WaitCondition:
+  WaitCondition:  # Waits for the handle to say success
     Type: AWS::CloudFormation::WaitCondition
     DependsOn:
     - Cloud9BootstrapInstanceLambda
@@ -644,7 +643,7 @@ Resources:
       Handle: !Ref WaitHandle
       Timeout: '3600'
 
-  LambdaGetHeadNodeIP:
+  LambdaGetHeadNodeIP:  # Wait until headnode and cluster setup completed
     Type: AWS::Lambda::Function
     Properties:
       Code:
@@ -687,7 +686,7 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${LambdaGetHeadNodeIP}
       RetentionInDays: 7
 
-  HeadNodeIP:
+  HeadNodeIP:  # After cluster created (previous lambda reports success), gets HeadNode IP
     Type: Custom::HeadNodeIP
     DependsOn: 
     - WaitCondition
@@ -730,7 +729,7 @@ Resources:
         - ${AWS::StackName}-${RANDOM}
         - RANDOM: !Select [0, !Split ['-', !Select [2, !Split ['/', !Ref 'AWS::StackId' ]]]]
 
-  Cloud9OutputBucket:
+  Cloud9OutputBucket:  # Creates Bucket to hold postinstall scripts - need to retain bucket after delete, because bucket needs to be empty to successfully delete
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
@@ -758,7 +757,7 @@ Resources:
       VpcEndpointType: Gateway
       VpcId: !Ref VPC
 
-  LBInit:
+  LBInit:  # Sets up Application Load Balancer, adding certificates etc.
     Type: Custom::LBInit
     DependsOn: 
       - LogGroupLBInitLambda
@@ -774,7 +773,7 @@ Resources:
       LogGroupName: !Sub /aws/lambda/${LBInitLambda}
       RetentionInDays: 7
 
-  LBInitLambda:
+  LBInitLambda:  # Create ALB certificate
     Type: AWS::Lambda::Function
     Properties:
       Description: Create ALB Certificate
@@ -1105,7 +1104,7 @@ Resources:
         - Key: Name
           Value: !Sub ${AWS::StackName}-GetAZLambdaFunction
 
-  ActiveDirectory:
+  ActiveDirectory:  # Create Managed Active Directory (standard) to handle cluster users
     Type: AWS::DirectoryService::MicrosoftAD
     Condition: CreateAD
     Properties: 

--- a/parallelcluster/config.ap-east-1.sample.yaml
+++ b/parallelcluster/config.ap-east-1.sample.yaml
@@ -83,6 +83,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -126,6 +127,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -164,6 +166,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -214,6 +217,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -269,6 +273,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -324,6 +329,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true

--- a/parallelcluster/config.ap-northeast-1.sample.yaml
+++ b/parallelcluster/config.ap-northeast-1.sample.yaml
@@ -104,6 +104,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -153,6 +154,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -196,6 +198,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -246,6 +249,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -289,6 +293,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -345,6 +350,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -400,6 +406,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -455,6 +462,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -512,6 +520,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true

--- a/parallelcluster/config.ap-northeast-2.sample.yaml
+++ b/parallelcluster/config.ap-northeast-2.sample.yaml
@@ -97,6 +97,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -139,6 +140,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -182,6 +184,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -225,6 +228,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -281,6 +285,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -331,6 +336,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -386,6 +392,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -443,6 +450,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true

--- a/parallelcluster/config.ap-south-1.sample.yaml
+++ b/parallelcluster/config.ap-south-1.sample.yaml
@@ -90,6 +90,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -132,6 +133,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -175,6 +177,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -218,6 +221,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -267,6 +271,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -322,6 +327,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -377,6 +383,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -434,6 +441,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true

--- a/parallelcluster/config.ca-central-1.sample.yaml
+++ b/parallelcluster/config.ca-central-1.sample.yaml
@@ -76,6 +76,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -118,6 +119,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -161,6 +163,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -204,6 +207,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -239,6 +243,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -289,6 +294,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -344,6 +350,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -401,6 +408,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true

--- a/parallelcluster/config.eu-central-1.sample.yaml
+++ b/parallelcluster/config.eu-central-1.sample.yaml
@@ -83,6 +83,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -139,6 +140,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -181,6 +183,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -224,6 +227,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -267,6 +271,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -309,6 +314,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -364,6 +370,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -419,6 +426,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -476,6 +484,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true

--- a/parallelcluster/config.eu-north-1.sample.yaml
+++ b/parallelcluster/config.eu-north-1.sample.yaml
@@ -90,6 +90,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -133,6 +134,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -176,6 +178,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -226,6 +229,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -281,6 +285,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -336,6 +341,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true

--- a/parallelcluster/config.eu-south-1.sample.yaml
+++ b/parallelcluster/config.eu-south-1.sample.yaml
@@ -76,6 +76,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -119,6 +120,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -162,6 +164,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -212,6 +215,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -267,6 +271,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -322,6 +327,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true

--- a/parallelcluster/config.eu-west-1.sample.yaml
+++ b/parallelcluster/config.eu-west-1.sample.yaml
@@ -104,6 +104,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -160,6 +161,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -202,6 +204,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -245,6 +248,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -288,6 +292,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -344,6 +349,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -399,6 +405,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -454,6 +461,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -511,6 +519,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true

--- a/parallelcluster/config.us-east-1.sample.yaml
+++ b/parallelcluster/config.us-east-1.sample.yaml
@@ -104,6 +104,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -160,6 +161,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -202,6 +204,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -245,6 +248,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -283,6 +287,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -339,6 +344,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -394,6 +400,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -449,6 +456,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -506,6 +514,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true

--- a/parallelcluster/config.us-east-2.sample.yaml
+++ b/parallelcluster/config.us-east-2.sample.yaml
@@ -104,6 +104,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -160,6 +161,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -202,6 +204,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -245,6 +248,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -288,6 +292,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -344,6 +349,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -399,6 +405,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -454,6 +461,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -511,6 +519,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true

--- a/parallelcluster/config.us-west-1.sample.yaml
+++ b/parallelcluster/config.us-west-1.sample.yaml
@@ -97,6 +97,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -139,6 +140,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -182,6 +184,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -225,6 +228,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -281,6 +285,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -336,6 +341,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -391,6 +397,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -448,6 +455,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true

--- a/parallelcluster/config.us-west-2.sample.yaml
+++ b/parallelcluster/config.us-west-2.sample.yaml
@@ -104,6 +104,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -160,6 +161,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -202,6 +204,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -245,6 +248,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -288,6 +292,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -344,6 +349,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -399,6 +405,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -454,6 +461,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true
@@ -511,6 +519,7 @@ Scheduling:
           - Policy: arn:aws:iam::aws:policy/AWSPriceListServiceFullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonSSMFullAccess
           - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+          - Policy: arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
         S3Access:
           - BucketName: '*'
             EnableWriteAccess: true

--- a/scripts/Cloud9-Bootstrap.sh
+++ b/scripts/Cloud9-Bootstrap.sh
@@ -138,8 +138,7 @@ aws ec2 modify-instance-attribute --instance-id $INSTANCE_ID --groups $SG_CLOUD9
 sudo bash -c 'echo "fs.inotify.max_user_watches=524288" >> /etc/sysctl.conf' && sudo sysctl -p
 
 if [[ $FSX_ID == "AUTO" ]];then
-  FSX_STACK_NAME=$(aws cloudformation describe-stack-resources --stack-name "hpc-1click-${CLUSTER_NAME}" --logical-resource-id FSXSubstack --query "StackResources[*].PhysicalResourceId" --output text)
-  FSX_ID=$(aws cloudformation describe-stacks --stack-name $FSX_STACK_NAME --query "Stacks[*].Outputs[*].OutputValue" --output text)
+  FSX_ID=$(aws cloudformation describe-stack-resources --stack-name "hpc-1click-${CLUSTER_NAME}" --logical-resource-id FSX0 --query "StackResources[*].PhysicalResourceId" --output text)
 fi
 
 FSX_DNS_NAME=$(aws fsx describe-file-systems --file-system-ids $FSX_ID --query "FileSystems[*].DNSName" --output text)

--- a/scripts/prolog.sh
+++ b/scripts/prolog.sh
@@ -36,7 +36,7 @@ tags=$($SLURM_ROOT/bin/scontrol show job ${SLURM_JOB_ID} | grep Comment  | sed '
 
 
 #expand the hostnames
-hosts=$($SLURM_ROOT/bin/scontrol show hostnames ${SLURM_NODELIST})
+hosts=$($SLURM_ROOT/bin/scontrol show hostnames ${SLURM_JOB_NODELIST})
 
 instance_id_list=""
 #verify each host
@@ -53,7 +53,6 @@ for host in $hosts
    fi
 done
 
-#fix this
 for host in $instance_id_list
 do
   #consider API throttling 


### PR DESCRIPTION
Following fixes/additions:
- Fixed a bug in Cloud9-Bootstrap to mount the FSx File system to the cloud9 instance
- Fixed bugs in prolog script to allow tagging of instances
- Added IAM policy to compute nodes to allow prolog script to run and tag EC2 instances

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
