### PR TITLE
Prolog script edits to reduce scaling issues reported in #34

### DIFF
--- a/Templates/AWS-HPC-Cluster.yaml
+++ b/Templates/AWS-HPC-Cluster.yaml
@@ -568,7 +568,7 @@ Resources:
     Properties:
       Handler: index.lambda_handler
       Role: !GetAtt LambdaExecutionRole.Arn
-      Runtime: python3.6
+      Runtime: python3.8
       MemorySize: 256
       Timeout: 600
       Code:


### PR DESCRIPTION
*Issue #, if available:* #34

*Description of changes:*
Prolog script is run once on every compute node after it is initialized, so removed for loops and removed need to check if compute nodes up first. Also allowed reduced calls to scontrol (which is discouraged in slurm docs), but still has one call to scontrol per compute node to retrieve job comments. Exploring spank plugins for a better solution in a future commit.

Also updates python version for lambda function causing deployment error as v3.6 no longer supported.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
