### PR TITLE
PC 3.6 fixes

### DIFF
--- a/Templates/AWS-HPC-Cluster.yaml
+++ b/Templates/AWS-HPC-Cluster.yaml
@@ -76,6 +76,12 @@ Parameters:
       AllowedPattern: ^(AUTO|ldaps?://.+)$
       Default : AUTO
 
+    GitHubUrl:
+      Description: 'Location of installation files'
+      Type: String
+      AllowedPattern: ^https://.*$
+      Default: https://github.com/aws-samples/1click-hpc
+
 Conditions:
   CreateVpc: !Equals [!Ref VpcId, AUTO]
   CreateAD: !Equals [!Ref AD, AUTO]
@@ -364,7 +370,7 @@ Resources:
             - echo LANG=en_US.utf-8 >> /etc/environment
             - echo LC_ALL=en_US.UTF-8 >> /etc/environment
             - cd /home/ec2-user/environment
-            - git clone "https://github.com/aws-samples/1click-hpc"
+            - !Sub git clone ${GitHubUrl}"
             - !Sub echo "export AWS_DEFAULT_REGION=${AWS::Region}" >> cluster_env
             - !Sub echo "export AWS_REGION_NAME=${AWS::Region}" >> cluster_env
             - !Sub echo "export S3_BUCKET=${Cloud9OutputBucket}" >> cluster_env

--- a/Templates/AWS-HPC-Cluster.yaml
+++ b/Templates/AWS-HPC-Cluster.yaml
@@ -370,7 +370,7 @@ Resources:
             - echo LANG=en_US.utf-8 >> /etc/environment
             - echo LC_ALL=en_US.UTF-8 >> /etc/environment
             - cd /home/ec2-user/environment
-            - !Sub git clone ${GitHubUrl}"
+            - !Sub git clone ${GitHubUrl}
             - !Sub echo "export AWS_DEFAULT_REGION=${AWS::Region}" >> cluster_env
             - !Sub echo "export AWS_REGION_NAME=${AWS::Region}" >> cluster_env
             - !Sub echo "export S3_BUCKET=${Cloud9OutputBucket}" >> cluster_env

--- a/scripts/Cloud9-Bootstrap.sh
+++ b/scripts/Cloud9-Bootstrap.sh
@@ -54,10 +54,12 @@ export FSX
 /usr/bin/envsubst '${SLURM_DB_ENDPOINT}' < "1click-hpc/enginframe/mysql/efdb.config" > efdb.config
 /usr/bin/envsubst '${SLURM_DB_ENDPOINT}' < "1click-hpc/enginframe/efinstall.config" > efinstall.config
 /usr/bin/envsubst '${S3_BUCKET}' < "1click-hpc/enginframe/fm.browse.ui" > fm.browse.ui
+/usr/bin/envsubst '${S3_BUCKET}' < "1click-hpc/scripts/post.install.sh" > post.install.sh
 
 aws s3 cp --quiet efinstall.config "s3://${S3_BUCKET}/1click-hpc/enginframe/efinstall.config" --region "${AWS_REGION_NAME}"
 aws s3 cp --quiet fm.browse.ui "s3://${S3_BUCKET}/1click-hpc/enginframe/fm.browse.ui" --region "${AWS_REGION_NAME}"
 aws s3 cp --quiet efdb.config "s3://${S3_BUCKET}/1click-hpc/enginframe/mysql/efdb.config" --region "${AWS_REGION_NAME}"
+aws s3 cp --quiet post.install.sh "s3://${S3_BUCKET}/1click-hpc/scripts/post.install.sh" --region "${AWS_REGION_NAME}
 aws s3 cp --quiet /usr/bin/mysql "s3://${S3_BUCKET}/1click-hpc/enginframe/mysql/mysql" --region "${AWS_REGION_NAME}"
 rm -f fm.browse.ui efinstall.config
 

--- a/scripts/Cloud9-Bootstrap.sh
+++ b/scripts/Cloud9-Bootstrap.sh
@@ -59,7 +59,7 @@ export FSX
 aws s3 cp --quiet efinstall.config "s3://${S3_BUCKET}/1click-hpc/enginframe/efinstall.config" --region "${AWS_REGION_NAME}"
 aws s3 cp --quiet fm.browse.ui "s3://${S3_BUCKET}/1click-hpc/enginframe/fm.browse.ui" --region "${AWS_REGION_NAME}"
 aws s3 cp --quiet efdb.config "s3://${S3_BUCKET}/1click-hpc/enginframe/mysql/efdb.config" --region "${AWS_REGION_NAME}"
-aws s3 cp --quiet post.install.sh "s3://${S3_BUCKET}/1click-hpc/scripts/post.install.sh" --region "${AWS_REGION_NAME}
+aws s3 cp --quiet post.install.sh "s3://${S3_BUCKET}/1click-hpc/scripts/post.install.sh" --region "${AWS_REGION_NAME}"
 aws s3 cp --quiet /usr/bin/mysql "s3://${S3_BUCKET}/1click-hpc/enginframe/mysql/mysql" --region "${AWS_REGION_NAME}"
 rm -f fm.browse.ui efinstall.config
 

--- a/scripts/Cloud9-Bootstrap.sh
+++ b/scripts/Cloud9-Bootstrap.sh
@@ -54,7 +54,7 @@ export FSX
 /usr/bin/envsubst '${SLURM_DB_ENDPOINT}' < "1click-hpc/enginframe/mysql/efdb.config" > efdb.config
 /usr/bin/envsubst '${SLURM_DB_ENDPOINT}' < "1click-hpc/enginframe/efinstall.config" > efinstall.config
 /usr/bin/envsubst '${S3_BUCKET}' < "1click-hpc/enginframe/fm.browse.ui" > fm.browse.ui
-/usr/bin/envsubst '${S3_BUCKET}' < "1click-hpc/scripts/post.install.sh" > post.install.sh
+/usr/bin/envsubst '${POST_INSTALL}' < "1click-hpc/scripts/post.install.sh" > post.install.sh
 
 aws s3 cp --quiet efinstall.config "s3://${S3_BUCKET}/1click-hpc/enginframe/efinstall.config" --region "${AWS_REGION_NAME}"
 aws s3 cp --quiet fm.browse.ui "s3://${S3_BUCKET}/1click-hpc/enginframe/fm.browse.ui" --region "${AWS_REGION_NAME}"

--- a/scripts/post.install.sh
+++ b/scripts/post.install.sh
@@ -27,7 +27,7 @@ set +a
 # runs secondary scripts according to the node type
 runScripts() {
     
-    echo "Getting packages from ${post_install_url}"
+    echo "Getting packages from ${post_install_base}"
     for script in "${@}"; do
         aws s3 cp --quiet ${post_install_base}/modules/${script} "${TMP_MODULES_DIR}" --region "${cfn_region}" || exit 1
     done
@@ -43,12 +43,10 @@ main() {
     runScripts "${@}"
     echo "[INFO][$(date '+%Y-%m-%d %H:%M:%S')] post.install.sh: STOP" >&2
 }
-
 TMP_MODULES_DIR="/tmp/modules/"
 export host_name=$(hostname -s)
 export SLURM_CONF_FILE="/opt/slurm/etc/pcluster/slurm_parallelcluster_*_partition.conf"
-post_install_url=$(dirname ${cfn_postinstall})
-export post_install_base=$(dirname "${post_install_url}")
+export post_install_base=${S3_BUCKET}
 SLURM_ROOT="/opt/slurm"
 export SLURM_ETC="${SLURM_ROOT}/etc"
 export SHARED_FS_DIR="$(cat /etc/parallelcluster/shared_storages_data.yaml | grep mount_dir | awk '{print $2}')"

--- a/scripts/post.install.sh
+++ b/scripts/post.install.sh
@@ -46,7 +46,7 @@ main() {
 TMP_MODULES_DIR="/tmp/modules/"
 export host_name=$(hostname -s)
 export SLURM_CONF_FILE="/opt/slurm/etc/pcluster/slurm_parallelcluster_*_partition.conf"
-post_install_url=$(dirname ${S3_BUCKET})
+post_install_url=$(dirname ${POST_INSTALL})
 export post_install_base=$(dirname "${post_install_url}")
 SLURM_ROOT="/opt/slurm"
 export SLURM_ETC="${SLURM_ROOT}/etc"

--- a/scripts/post.install.sh
+++ b/scripts/post.install.sh
@@ -27,7 +27,7 @@ set +a
 # runs secondary scripts according to the node type
 runScripts() {
     
-    echo "Getting packages from ${post_install_base}"
+    echo "Getting packages from ${post_install_url}"
     for script in "${@}"; do
         aws s3 cp --quiet ${post_install_base}/modules/${script} "${TMP_MODULES_DIR}" --region "${cfn_region}" || exit 1
     done
@@ -46,7 +46,8 @@ main() {
 TMP_MODULES_DIR="/tmp/modules/"
 export host_name=$(hostname -s)
 export SLURM_CONF_FILE="/opt/slurm/etc/pcluster/slurm_parallelcluster_*_partition.conf"
-export post_install_base=${S3_BUCKET}
+post_install_url=$(dirname ${S3_BUCKET})
+export post_install_base=$(dirname "${post_install_url}")
 SLURM_ROOT="/opt/slurm"
 export SLURM_ETC="${SLURM_ROOT}/etc"
 export SHARED_FS_DIR="$(cat /etc/parallelcluster/shared_storages_data.yaml | grep mount_dir | awk '{print $2}')"


### PR DESCRIPTION
*Issue #:* #40

*Description of changes:*
This injects the S3 bucket location into `post.install.sh` rather than having it try to read from `/etc/parallelcluster/cfnconfig`.

Also added a GitHubUrl to the Cluster CFN, this allows for a bit of customization and helped me with the regression testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
