### PR TITLE
status checks

### DIFF
--- a/scripts/Cloud9-Bootstrap.sh
+++ b/scripts/Cloud9-Bootstrap.sh
@@ -73,9 +73,12 @@ fi
 sudo chmod 400 /home/ec2-user/.ssh/id_rsa
 
 #Create the cluster and wait
-/home/ec2-user/.local/bin/pcluster create-cluster --cluster-name "hpc-1click-${CLUSTER_NAME}" --cluster-configuration config.${AWS_REGION_NAME}.yaml --rollback-on-failure false --wait
+CLUSTER_FULLNAME="hpc-1click-${CLUSTER_NAME}"
+/home/ec2-user/.local/bin/pcluster create-cluster --cluster-name "${CLUSTER_FULLNAME}" --cluster-configuration config.${AWS_REGION_NAME}.yaml --rollback-on-failure false
+cstatus='"CREATE_IN_PROGRESS"'; until [ ${cstatus} != '"CREATE_IN_PROGRESS"' ]; do sleep 10; cstatus=$(/home/ec2-user/.local/bin/pcluster describe-cluster -n "${CLUSTER_FULLNAME}" --query clusterStatus); done;
 
-HEADNODE_PRIVATE_IP=$(/home/ec2-user/.local/bin/pcluster describe-cluster --cluster-name "hpc-1click-${CLUSTER_NAME}" | jq -r '.headNode.privateIpAddress')
+
+HEADNODE_PRIVATE_IP=$(/home/ec2-user/.local/bin/pcluster describe-cluster --cluster-name "${CLUSTER_FULLNAME}" | jq -r '.headNode.privateIpAddress')
 echo "export HEADNODE_PRIVATE_IP='${HEADNODE_PRIVATE_IP}'" >> cluster_env
 
 # Modify the Message Of The Day
@@ -87,14 +90,14 @@ echo 'run-parts /etc/update-motd.d' >> /home/ec2-user/.bash_profile
 #attach the ParallelCluster SG to the Cloud9 instance (for FSx or NFS)
 INSTANCE_ID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
 SG_CLOUD9=$(aws ec2 describe-instances --instance-ids $INSTANCE_ID --query Reservations[*].Instances[*].SecurityGroups[*].GroupId --output text)
-SG_HEADNODE=$(aws cloudformation describe-stack-resources --stack-name "hpc-1click-${CLUSTER_NAME}" --logical-resource-id ComputeSecurityGroup --query "StackResources[*].PhysicalResourceId" --output text)
+SG_HEADNODE=$(aws cloudformation describe-stack-resources --stack-name "${CLUSTER_FULLNAME}" --logical-resource-id ComputeSecurityGroup --query "StackResources[*].PhysicalResourceId" --output text)
 aws ec2 modify-instance-attribute --instance-id $INSTANCE_ID --groups $SG_CLOUD9 $SG_HEADNODE
 
 #increase the maximum number of files that can be handled by file watcher,
 sudo bash -c 'echo "fs.inotify.max_user_watches=524288" >> /etc/sysctl.conf' && sudo sysctl -p
 
 if [[ $FSX_ID == "AUTO" ]];then
-  FSX_ID=$(aws cloudformation describe-stack-resources --stack-name "hpc-1click-${CLUSTER_NAME}" --logical-resource-id FSX0 --query "StackResources[*].PhysicalResourceId" --output text)
+  FSX_ID=$(aws cloudformation describe-stack-resources --stack-name "${CLUSTER_FULLNAME}" --logical-resource-id FSX0 --query "StackResources[*].PhysicalResourceId" --output text)
 fi
 
 FSX_DNS_NAME=$(aws fsx describe-file-systems --file-system-ids $FSX_ID --query "FileSystems[*].DNSName" --output text)


### PR DESCRIPTION
*Issue #, if available:* #41

*Description of changes:*
Fixes issue 41, where `pcluster create-cluster --wait` was failing when the C9 EC2 credentials rotated. This moves to a loop on describe-cluster call instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
